### PR TITLE
Update README with swift-grpc tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ $ brew install swift-protobuf
 Install Swift GRPC. The following sometimes doesn't work. So follow the instructions on the Swift GRPC Github for the most accurate instructions
 ```
 $ git clone https://www.github.com/grpc/grpc-swift
+$ git checkout tags/0.4.0
 make install
 ```
 


### PR DESCRIPTION
If doing `$ ./gen_protos.sh`, need to have specific swift-grpc version.

This is per our discussion on [#20](https://github.com/biscottigelato/SwiftLightning/issues/17), and should close it if it makes sense to you.

I've tested it on my end and got it working consistently this weekend.